### PR TITLE
openPMD-api: 0.14.*

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ install_requires =
     numpy
     scipy
     h5py
-    openpmd-api~=0.13.0
+    openpmd-api~=0.13.0,~=0.14.0


### PR DESCRIPTION
Adding compatibility with the 0.14.* release series of openPMD-api.
There are no breaking changes to the 0.13 releases.

Changelog:
https://openpmd-api.readthedocs.io/en/0.14.2/install/changelog.html

Upgrade Guide:
https://openpmd-api.readthedocs.io/en/0.14.2/install/upgrade.html