### PR TITLE
Change openPMD reader defaults

### DIFF
--- a/aptools/__init__.py
+++ b/aptools/__init__.py
@@ -1,4 +1,4 @@
 from .data_analysis import beam_diagnostics
 
-__version__ = "0.1.24"
+__version__ = "0.1.25"
 __all__ = ['beam_diagnostics', '__version__']

--- a/aptools/data_handling/reading.py
+++ b/aptools/data_handling/reading.py
@@ -136,7 +136,7 @@ def read_astra_data(file_path, remove_non_standard=True):
     return x, y, z, px, py, pz, q
 
 
-def read_openpmd_beam(file_path, species_name):
+def read_openpmd_beam(file_path, species_name=None):
     """Reads particle data from a h5 file following the openPMD standard and
     returns it in the unis used by APtools.
 
@@ -145,8 +145,9 @@ def read_openpmd_beam(file_path, species_name):
     file_path : str
         Path to the file with particle data
 
-    species_name : str
-        Name of the particle species
+    species_name : str, Optional
+        Name of the particle species. Optional if only one particle species
+        is available in the openpmd file.
 
     Returns
     -------
@@ -159,6 +160,17 @@ def read_openpmd_beam(file_path, species_name):
     base_path = '/data/{}'.format(iteration)
     # get path under which particle data is stored
     particles_path = file_content.attrs['particlesPath'].decode()
+    # list available species
+    available_species = list(
+        file_content[join_infile_path(base_path, particles_path)])
+    if species_name is None:
+        if len(available_species) == 1:
+            species_name = available_species[0]
+        else:
+            raise ValueError(
+                'More than one particle species is available. '
+                'Please specify a `species_name`. '
+                'Available species are: ' + str(available_species))
     # get species
     beam_species = file_content[
         join_infile_path(base_path, particles_path, species_name)]

--- a/aptools/data_handling/utilities.py
+++ b/aptools/data_handling/utilities.py
@@ -1,0 +1,21 @@
+""" Defines utilities for the data handling modules """
+import openpmd_api as io
+
+
+def get_available_species(file_path):
+    """Get a list of available species in an openPMD file.
+
+    Parameters
+    ----------
+    file_path : str
+        Path of the openPMD file.
+
+    Returns
+    -------
+    list
+        A list of strings with the names of the available species.
+    """
+    series = io.Series(file_path, io.Access.read_only)
+    it = series.iterations[0]
+
+    return list(it.particles)

--- a/aptools/data_handling/utilities.py
+++ b/aptools/data_handling/utilities.py
@@ -16,6 +16,7 @@ def get_available_species(file_path):
         A list of strings with the names of the available species.
     """
     series = io.Series(file_path, io.Access.read_only)
-    it = series.iterations[0]
+    i = list(series.iterations)[0]
+    iteration = series.iterations[i]
 
-    return list(it.particles)
+    return list(iteration.particles)


### PR DESCRIPTION
This PR makes the `species_name` parameter of the openPMD reader optional when only one species is available (related to https://github.com/AngelFP/Wake-T/issues/70). It also adds a convenience method for printing the names of all available particle species in an openPMD file.