### PR TITLE
openPMD-api: Support 0.15.*

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,5 +23,5 @@ install_requires =
     numpy
     scipy
     h5py
-    openpmd-api~=0.14.0
+    openpmd-api~=0.14.0,~=0.15.0
     deprecated


### PR DESCRIPTION
The latest major release of openPMD-api should not have introduced breaking changes for us. Bumping compatibility range.

Same as #2