### PR TITLE
openPMD-api: 0.15.*

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,5 +23,5 @@ install_requires =
     numpy
     scipy
     h5py
-    openpmd-api~=0.14.0,~=0.15.0
+    openpmd-api ~=0.15.0
     deprecated

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,5 +23,5 @@ install_requires =
     numpy
     scipy
     h5py
-    openpmd-api ~=0.15.0
+    openpmd-api
     deprecated


### PR DESCRIPTION
Fix version range. For some reason, listing multiple ranges with `~=` does not work in `setup.cfg` files.

Update: remove upper version range limit, considered not best practice anyway.